### PR TITLE
fix shebang

### DIFF
--- a/bin/anbt-sql-formatter
+++ b/bin/anbt-sql-formatter
@@ -1,4 +1,4 @@
-#! /usr/bin/ruby1.8
+#! /usr/bin/env ruby
 # -*- coding: utf-8 -*-
 
 begin


### PR DESCRIPTION
anbt-sql-formatterを私のRailsプロジェクトで利用させて頂きたいと考えています。
そこでこちらのgemを組み込んだRilasアプリケーションをrpm化したところ、
shebangがruby1.8に固定されているためRuby1.8以外の環境では以下エラーが発生しました。

```
$ bin/anbt-sql-formatter
-bash: bin/anbt-sql-formatter: /usr/bin/ruby1.8: bad interpreter: No such file or directory
```

私のプロジェクトではアプリケーションをrpm化する際に
各gemのbin以下のファイルにshebangが設定されていたら、
そのパスの実行ファイルを依存関係に設定するようになっていて、
インストール時にRuby1.8が無いためエラーが出てしまうのです。

pull-requestでは環境変数から取得するように修正を加えています。
お手数ですが検討の程よろしくお願い致します。